### PR TITLE
Datapack new features ideas

### DIFF
--- a/data/sg/functions/states/pre_game.mcfunction
+++ b/data/sg/functions/states/pre_game.mcfunction
@@ -3,4 +3,4 @@ gamemode adventure @a[gamemode=survival]
 # Load chunk 0 0
 forceload add 0 0
 
-title @a actionbar [{"text": "Run ", "color": "green"},{"text":"/function sg:triggers/init", "color": "green", "bold": true},{"text":" to setup the pack", "color": "green"}]
+title @a actionbar [{"text": "Run ", "color": "green"},{"text":"/function sg:triggers/init", "color": "yellow", "bold": true},{"text":" to setup the pack", "color": "green"}]


### PR DESCRIPTION
First, I hope that you will add all of my ideas in your next HUGE update. I will list all of my ideas below:
- General:
+Make "/function sg:triggers/init" yellow in  "Run /function sg:triggers/init to setup the pack" to make the player easier to understand
+Add a new feature that gives everybody a drawn map before preloading that also tags your fellas (welp as y'know that preloading automatically draws the map)
- New gamemode: Hunger Games (or battle royale)
I know that you named the title of your Reddit post is "I made a hunger games datapack for a friend" but I feel like this datapack creates a survival game same as a normal survival world with borders and pvps? So I'd like to give you some ideas to the "Hunger games" mode:
- Airdrops:
+Yeah, airdrops is the thing that all PUBG or FF players run straight at as they knew that it's dropping somewhere, so the airdrop will be dropped from a flying ender dragon and drop a 3x3x3 block of gravel (signaled on the map and dragon sound plays to all) that if it lands, a chest appears at the bottom and the pile of gravel will be deleted
+Flare gun: we will replace that with a tagged firework
- Airstrikes
+At some moment, a bunch of ender dragons fly quickly through the sky and drops tagged things (arrows?) and summon primed TNTs
- Loot chests
+Before the game starts, gravels will fall from the sky and summon a contented chest after it lands
- Final borders
+The final border will be shrunk into the “Anchor armor stand” and if the safe zone is down to 1 block, the border center will be teleported far away so that all players will be damaged and the game soon ends
And that is all of my ideas, feel free to contribute and edit!
